### PR TITLE
Paginated GetObject WithRelations on v3.reader

### DIFF
--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -60,6 +60,30 @@ service Reader {
         };
     };
 
+    // relation methods
+    rpc GetRelation(GetRelationRequest) returns (GetRelationResponse) {
+        option (google.api.http) = {
+            get: "/api/v3/directory/relation/{object_type}/{object_id}/{relation}/{subject_type}/{subject_id}/{subject_relation}"
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: "directory"
+            summary: "Get relation instance"
+            description: "Returns single relation instance, optionally with objects."
+            operation_id: "directory.v3.relation.get"
+            deprecated: false
+            security: {
+                security_requirement: {
+                    key: "TenantID";
+                    value: {}
+                }
+                security_requirement: {
+                    key: "DirectoryAPIKey";
+                    value: {}
+                }
+            }
+        };
+    };
+
     rpc GetRelations(GetRelationsRequest) returns (GetRelationsResponse) {
         option (google.api.http) = {
             post: "/api/v3/directory/relations"
@@ -166,7 +190,7 @@ message GetObjectRequest {
     // object identifier (cs-string)
     string object_id                                            = 2     [(google.api.field_behavior) = REQUIRED];
     // include object relations
-    bool with_relations                                         = 3;
+    bool with_relations                                         = 3     [(google.api.field_behavior) = OPTIONAL];
     // pagination request
     aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
 }
@@ -206,6 +230,30 @@ message GetObjectsResponse {
     aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+message GetRelationRequest {
+    // object type
+    string object_type                                          = 1     [(google.api.field_behavior) = REQUIRED];
+    // object identifier
+    string object_id                                            = 2     [(google.api.field_behavior) = REQUIRED];
+    // relation name
+    string relation                                             = 3     [(google.api.field_behavior) = REQUIRED];
+    // subject type
+    string subject_type                                         = 4     [(google.api.field_behavior) = REQUIRED];
+    // subject identifier
+    string subject_id                                           = 5     [(google.api.field_behavior) = REQUIRED];
+    // optional subject relation name
+    string subject_relation                                     = 6     [(google.api.field_behavior) = OPTIONAL];
+    // materialize relation objects
+    optional bool with_objects                                  = 7     [(google.api.field_behavior) = OPTIONAL];
+}
+
+message GetRelationResponse {
+    // relation instance
+    aserto.directory.common.v3.Relation result                  = 1;
+    // map from "<type>:<key>" to materialized relation objects
+    map<string, aserto.directory.common.v3.Object> objects      = 2;
+}
+
 message GetRelationsRequest {
     // object type
     string object_type                                          = 1     [(google.api.field_behavior) = OPTIONAL];
@@ -228,7 +276,7 @@ message GetRelationsRequest {
 message GetRelationsResponse {
     // array of relation instances
     repeated aserto.directory.common.v3.Relation results        = 1;
-    // map of materialized relation objects
+    // map from "<type>:<key>" to materialized relation objects
     map<string, aserto.directory.common.v3.Object> objects      = 2;
     // pagination response
     aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -194,10 +194,6 @@ message GetObjectRequest {
 message GetObjectResponse {
     // object instance
     aserto.directory.common.v3.Object result                    = 1;
-    // incoming object relations
-    repeated aserto.directory.common.v3.Relation incoming       = 2;
-    // outgoing object relations
-    repeated aserto.directory.common.v3.Relation outgoing       = 3;
 }
 
 message GetObjectManyRequest {

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -225,25 +225,10 @@ message GetObjectRelationsRequest {
     string object_type                                          = 1     [(google.api.field_behavior) = REQUIRED];
     // object identifier
     string object_id                                            = 2     [(google.api.field_behavior) = REQUIRED];
-    // diretion of relations to get
-    RelationsTo relations_to                                    = 3     [(google.api.field_behavior) = REQUIRED];
-    // optional filter on object type
-    string neighbor_type                                        = 4     [(google.api.field_behavior) = OPTIONAL];
-    // optional filter on relation type
-    string relation                                             = 5     [(google.api.field_behavior) = OPTIONAL];
-    // optional filter on subject relation name
-    string subject_relation                                     = 6     [(google.api.field_behavior) = OPTIONAL];
     // materialize relation objects
-    bool with_objects                                           = 7     [(google.api.field_behavior) = OPTIONAL];
+    bool with_objects                                           = 3     [(google.api.field_behavior) = OPTIONAL];
     // pagination request
     aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
-}
-
-enum RelationsTo {
-    RELATIONS_TO_UNKNOWN                                        = 0;
-    RELATIONS_TO_SUBJECTS                                       = 1;
-    RELATIONs_TO_OBJECTS                                        = 2;
-    RELATIONS_TO_BOTH                                           = 3;
 }
 
 message GetObjectRelationsResponse {
@@ -268,6 +253,8 @@ message GetRelationsRequest {
     string subject_id                                           = 5     [(google.api.field_behavior) = OPTIONAL];
     // optional subject relation name
     string subject_relation                                     = 6     [(google.api.field_behavior) = OPTIONAL];
+    // materialize relation objects
+    bool with_objects                                           = 7     [(google.api.field_behavior) = OPTIONAL];
     // pagination request
     aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
 }
@@ -275,6 +262,8 @@ message GetRelationsRequest {
 message GetRelationsResponse {
     // array of relation instances
     repeated aserto.directory.common.v3.Relation results        = 1;
+    // map of materialized relation objects
+    map<string, aserto.directory.common.v3.Object> objects      = 2;
     // pagination response
     aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -61,15 +61,15 @@ service Reader {
     };
 
     // relation methods
-    rpc GetRelation(GetRelationRequest) returns (GetRelationResponse) {
+    rpc GetObjectRelations(GetObjectRelationsRequest) returns (GetObjectRelationsResponse) {
         option (google.api.http) = {
-            get: "/api/v3/directory/relation/{object_type}/{object_id}/{relation}/{subject_type}/{subject_id}/{subject_relation}"
+            post: "/api/v3/directory/relation/{object_type}/{object_id}/relations"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
-            summary: "Get relation instance"
-            description: "Returns single relation instance, optionally with objects."
-            operation_id: "directory.v3.relation.get"
+            summary: "Get relations for object instance"
+            description: "Returns relation instances that include a given object instance."
+            operation_id: "directory.v3.object.relations"
             deprecated: false
             security: {
                 security_requirement: {
@@ -189,8 +189,6 @@ message GetObjectRequest {
     string object_type                                          = 1     [(google.api.field_behavior) = REQUIRED];
     // object identifier (cs-string)
     string object_id                                            = 2     [(google.api.field_behavior) = REQUIRED];
-    // materialize the object relations objects
-    optional bool with_relations                                = 3     [(google.api.field_behavior) = OPTIONAL];
 }
 
 message GetObjectResponse {
@@ -226,28 +224,39 @@ message GetObjectsResponse {
     aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-message GetRelationRequest {
+message GetObjectRelationsRequest {
     // object type
     string object_type                                          = 1     [(google.api.field_behavior) = REQUIRED];
     // object identifier
     string object_id                                            = 2     [(google.api.field_behavior) = REQUIRED];
-    // relation name
-    string relation                                             = 3     [(google.api.field_behavior) = REQUIRED];
-    // subject type
-    string subject_type                                         = 4     [(google.api.field_behavior) = REQUIRED];
-    // subject identifier
-    string subject_id                                           = 5     [(google.api.field_behavior) = REQUIRED];
-    // optional subject relation name
+    // diretion of relations to get
+    RelationsTo relations_to                                    = 3     [(google.api.field_behavior) = REQUIRED];
+    // optional filter on object type
+    string neighbor_type                                        = 4     [(google.api.field_behavior) = OPTIONAL];
+    // optional filter on relation type
+    string relation                                             = 5     [(google.api.field_behavior) = OPTIONAL];
+    // optional filter on subject relation name
     string subject_relation                                     = 6     [(google.api.field_behavior) = OPTIONAL];
     // materialize relation objects
-    optional bool with_objects                                  = 7     [(google.api.field_behavior) = OPTIONAL];
+    bool with_objects                                           = 7     [(google.api.field_behavior) = OPTIONAL];
+    // pagination request
+    aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
 }
 
-message GetRelationResponse {
+enum RelationsTo {
+    RELATIONS_TO_UNKNOWN                                        = 0;
+    RELATIONS_TO_SUBJECTS                                       = 1;
+    RELATIONs_TO_OBJECTS                                        = 2;
+    RELATIONS_TO_BOTH                                           = 3;
+}
+
+message GetObjectRelationsResponse {
     // array of relation instances
     repeated aserto.directory.common.v3.Relation results        = 1;
     // map of materialized relation objects
     map<string, aserto.directory.common.v3.Object> objects      = 2;
+    // pagination response
+    aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 message GetRelationsRequest {

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -60,30 +60,6 @@ service Reader {
         };
     };
 
-    // relation methods
-    rpc GetObjectRelations(GetObjectRelationsRequest) returns (GetObjectRelationsResponse) {
-        option (google.api.http) = {
-            get: "/api/v3/directory/objects/{object_type}/{object_id}/relations"
-        };
-        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            tags: "directory"
-            summary: "Get relations for object instance"
-            description: "Returns relation instances that include a given object instance."
-            operation_id: "directory.v3.object.relations"
-            deprecated: false
-            security: {
-                security_requirement: {
-                    key: "TenantID";
-                    value: {}
-                }
-                security_requirement: {
-                    key: "DirectoryAPIKey";
-                    value: {}
-                }
-            }
-        };
-    };
-
     rpc GetRelations(GetRelationsRequest) returns (GetRelationsResponse) {
         option (google.api.http) = {
             post: "/api/v3/directory/relations"
@@ -189,11 +165,21 @@ message GetObjectRequest {
     string object_type                                          = 1     [(google.api.field_behavior) = REQUIRED];
     // object identifier (cs-string)
     string object_id                                            = 2     [(google.api.field_behavior) = REQUIRED];
+    // include object relations
+    bool with_relations                                         = 3;
+    // pagination request
+    aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
 }
 
 message GetObjectResponse {
     // object instance
     aserto.directory.common.v3.Object result                    = 1;
+    // incoming object relations
+    repeated aserto.directory.common.v3.Relation incoming       = 2;
+    // outgoing object relations
+    repeated aserto.directory.common.v3.Relation outgoing       = 3;
+    // pagination response
+    aserto.directory.common.v3.PaginationResponse page          = 9;
 }
 
 message GetObjectManyRequest {
@@ -216,26 +202,6 @@ message GetObjectsRequest {
 message GetObjectsResponse {
     // array of object instances
     repeated aserto.directory.common.v3.Object results          = 1;
-    // pagination response
-    aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-message GetObjectRelationsRequest {
-    // object type
-    string object_type                                          = 1     [(google.api.field_behavior) = REQUIRED];
-    // object identifier
-    string object_id                                            = 2     [(google.api.field_behavior) = REQUIRED];
-    // materialize relation objects
-    bool with_objects                                           = 3     [(google.api.field_behavior) = OPTIONAL];
-    // pagination request
-    aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
-}
-
-message GetObjectRelationsResponse {
-    // array of relation instances
-    repeated aserto.directory.common.v3.Relation results        = 1;
-    // map of materialized relation objects
-    map<string, aserto.directory.common.v3.Object> objects      = 2;
     // pagination response
     aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -63,7 +63,7 @@ service Reader {
     // relation methods
     rpc GetObjectRelations(GetObjectRelationsRequest) returns (GetObjectRelationsResponse) {
         option (google.api.http) = {
-            post: "/api/v3/directory/relation/{object_type}/{object_id}/relations"
+            get: "/api/v3/directory/objects/{object_type}/{object_id}/relations"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"


### PR DESCRIPTION
This PR adds a `WithRelations` boolean flag to `GetObject`.
Results are paginated, allowing callers to iterate over _all_ relations that an object has.
Results are split into incoming and outgoing relations.