### PR TITLE
REST API refinements

### DIFF
--- a/proto/aserto/directory/common/v3/common.proto
+++ b/proto/aserto/directory/common/v3/common.proto
@@ -48,7 +48,7 @@ message Relation {
 
 message ObjectDependency {
     // object type
-    string object_type                                  = 1     [(google.api.field_behavior) = OUTPUT_ONLY];
+    string object_type                                  = 1    [(google.api.field_behavior) = OUTPUT_ONLY];
     // object identifier
     string object_id                                    = 2    [(google.api.field_behavior) = OUTPUT_ONLY];
     // object relation name

--- a/proto/aserto/directory/model/v3/model.proto
+++ b/proto/aserto/directory/model/v3/model.proto
@@ -40,6 +40,7 @@ service Model {
         //     }
         // };
     };
+
     rpc SetManifest(stream SetManifestRequest) returns (SetManifestResponse) {
         // Binary file uploads are not supported by grpc-gateway.
         // This endpoint is defined manually in openapi-directory.
@@ -67,9 +68,11 @@ service Model {
         //     }
         // };
     };
+
     rpc DeleteManifest(DeleteManifestRequest) returns (DeleteManifestResponse) {
         option (google.api.http) = {
-            delete: "/api/v3/directory/manifest/{name}/{version}"
+            delete: "/api/v3/directory/manifest"
+            body: "*"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -89,6 +92,7 @@ service Model {
             }
         };
     };
+
     rpc ListManifests(ListManifestsRequest) returns (ListManifestsResponse) {
         option (google.api.http) = {
             get: "/api/v3/directory/manifests"

--- a/proto/aserto/directory/model/v3/model.proto
+++ b/proto/aserto/directory/model/v3/model.proto
@@ -71,8 +71,7 @@ service Model {
 
     rpc DeleteManifest(DeleteManifestRequest) returns (DeleteManifestResponse) {
         option (google.api.http) = {
-            delete: "/api/v3/directory/manifest"
-            body: "*"
+            delete: "/api/v3/directory/manifest/{name}/{version}"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -14,7 +14,7 @@ service Reader {
     // object methods
     rpc GetObject(GetObjectRequest) returns (GetObjectResponse) {
         option (google.api.http) = {
-            get: "/api/v3/directory/object/{object_type}/{object_id}"
+            get: "/api/v3/directory/object"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -63,7 +63,7 @@ service Reader {
     // relation methods
     rpc GetRelation(GetRelationRequest) returns (GetRelationResponse) {
         option (google.api.http) = {
-            get: "/api/v3/directory/relation/{object_type}/{object_id}/{relation}/{subject_type}/{subject_id}/{subject_relation}"
+            get: "/api/v3/directory/relation"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -86,8 +86,7 @@ service Reader {
 
     rpc GetRelations(GetRelationsRequest) returns (GetRelationsResponse) {
         option (google.api.http) = {
-            post: "/api/v3/directory/relations"
-            body: "*"
+            get: "/api/v3/directory/relations"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -161,8 +160,7 @@ service Reader {
     // graph methods
     rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {
         option (google.api.http) = {
-            post: "/api/v3/directory/graph"
-            body: "*"
+            get: "/api/v3/directory/relations/{anchor_type}/{anchor_id}"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -246,8 +244,8 @@ message GetRelationRequest {
 }
 
 message GetRelationResponse {
-    // array of relation instances
-    repeated aserto.directory.common.v3.Relation results        = 1;
+    // relation instance
+    aserto.directory.common.v3.Relation result                  = 1;
     // map of materialized relation objects
     map<string, aserto.directory.common.v3.Object> objects      = 2;
 }
@@ -265,8 +263,6 @@ message GetRelationsRequest {
     string subject_id                                           = 5     [(google.api.field_behavior) = OPTIONAL];
     // optional subject relation name
     string subject_relation                                     = 6     [(google.api.field_behavior) = OPTIONAL];
-    // materialize relation objects
-    bool with_objects                                           = 7     [(google.api.field_behavior) = OPTIONAL];
     // pagination request
     aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
 }
@@ -274,8 +270,6 @@ message GetRelationsRequest {
 message GetRelationsResponse {
     // array of relation instances
     repeated aserto.directory.common.v3.Relation results        = 1;
-    // map of materialized relation objects
-    map<string, aserto.directory.common.v3.Object> objects      = 2;
     // pagination response
     aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -263,6 +263,8 @@ message GetRelationsRequest {
     string subject_id                                           = 5     [(google.api.field_behavior) = OPTIONAL];
     // optional subject relation name
     string subject_relation                                     = 6     [(google.api.field_behavior) = OPTIONAL];
+    // materialize relation objects
+    bool with_objects                                           = 7     [(google.api.field_behavior) = OPTIONAL];
     // pagination request
     aserto.directory.common.v3.PaginationRequest page           = 9     [(google.api.field_behavior) = OPTIONAL];
 }
@@ -270,6 +272,8 @@ message GetRelationsRequest {
 message GetRelationsResponse {
     // array of relation instances
     repeated aserto.directory.common.v3.Relation results        = 1;
+    // map of materialized relation objects
+    map<string, aserto.directory.common.v3.Object> objects      = 2;
     // pagination response
     aserto.directory.common.v3.PaginationResponse page          = 9     [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -14,7 +14,7 @@ service Reader {
     // object methods
     rpc GetObject(GetObjectRequest) returns (GetObjectResponse) {
         option (google.api.http) = {
-            get: "/api/v3/directory/object"
+            get: "/api/v3/directory/object/{object_type}/{object_id}"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -160,7 +160,7 @@ service Reader {
     // graph methods
     rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {
         option (google.api.http) = {
-            get: "/api/v3/directory/relations/{anchor_type}/{anchor_id}"
+            get: "/api/v3/directory/graph/{anchor_type}/{anchor_id}"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"

--- a/proto/aserto/directory/writer/v3/writer.proto
+++ b/proto/aserto/directory/writer/v3/writer.proto
@@ -39,8 +39,7 @@ service Writer {
 
     rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {
         option (google.api.http) = {
-            delete: "/api/v3/directory/object"
-            body: "*"
+            delete: "/api/v3/directory/object/{object_type}/{object_id}"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -89,7 +88,6 @@ service Writer {
     rpc DeleteRelation(DeleteRelationRequest) returns (DeleteRelationResponse) {
         option (google.api.http) = {
             delete: "/api/v3/directory/relation"
-            body: "*"
        };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"

--- a/proto/aserto/directory/writer/v3/writer.proto
+++ b/proto/aserto/directory/writer/v3/writer.proto
@@ -39,7 +39,8 @@ service Writer {
 
     rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {
         option (google.api.http) = {
-            delete: "/api/v3/directory/object/{object_type}/{object_id}"
+            delete: "/api/v3/directory/object"
+            body: "*"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"
@@ -87,7 +88,8 @@ service Writer {
 
     rpc DeleteRelation(DeleteRelationRequest) returns (DeleteRelationResponse) {
         option (google.api.http) = {
-            delete: "/api/v3/directory/relation/{object_type}/{object_id}/{relation}/{subject_type}/{subject_id}/{subject_relation}"
+            delete: "/api/v3/directory/relation"
+            body: "*"
        };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "directory"


### PR DESCRIPTION
- 0.30 -> v3 (#44)
- GetObject change object_type to query param to make optional
- Update model service (#38)
- remove unused import aserto/directory/common/v2/common.proto
- Remove Manifest message from v3.common (#45)
- add missing import google.protobuf.Timestamp
- REST API refinements
