### PR TITLE
fix get-relation(s) req validation

### DIFF
--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -414,10 +414,18 @@ message GetRelationRequest {
         (google.api.field_behavior) = OPTIONAL
     ];
 
+    // if object_id is set an object_type must be specified
     option (buf.validate.message).cel = {
-        id: "get_relation.directionality",
-        message: "either subject or object must be fully qualified (type + id) to determine graph directionality",
-        expression: "(this.object_type != '' && this.object_id != '') || (this.subject_type != '' && this.subject_id != '')"
+        id: "get_relation.object_id_with_type",
+        message: "when an object_id is specified, the accompanying object_type must be provided",
+        expression: "(this.object_type == '' && this.object_id == '') || (this.object_type != '' && this.object_id == '') || (this.object_type != '' && this.object_id != '')"
+    };
+
+    // if subject_id is set a subject_type must be specified
+    option (buf.validate.message).cel = {
+        id: "get_relation.subject_id_with_type",
+        message: "when an subject_id is specified, the accompanying subject_type must be provided",
+        expression: "(this.subject_type == '' && this.subject_id == '') || (this.subject_type != '' && this.subject_id == '') || (this.subject_type != '' && this.subject_id != '')"
     };
 }
 
@@ -536,10 +544,18 @@ message GetRelationsRequest {
         (google.api.field_behavior) = OPTIONAL
     ];
 
+    // if object_id is set an object_type must be specified
     option (buf.validate.message).cel = {
-        id: "get_relations.directionality",
-        message: "either subject or object must be fully qualified (type + id) to determine graph directionality",
-        expression: "(this.object_type != '' && this.object_id != '') || (this.subject_type != '' && this.subject_id != '')"
+        id: "get_relations.object_id_with_type",
+        message: "when an object_id is specified, the accompanying object_type must be provided",
+        expression: "(this.object_type == '' && this.object_id == '') || (this.object_type != '' && this.object_id == '') || (this.object_type != '' && this.object_id != '')"
+    };
+
+    // if subject_id is set a subject_type must be specified
+    option (buf.validate.message).cel = {
+        id: "get_relations.subject_id_with_type",
+        message: "when an subject_id is specified, the accompanying subject_type must be provided",
+        expression: "(this.subject_type == '' && this.subject_id == '') || (this.subject_type != '' && this.subject_id == '') || (this.subject_type != '' && this.subject_id != '')"
     };
 }
 

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,13 +4,13 @@ deps:
   - remote: buf.build
     owner: aserto-dev
     repository: aserto
-    commit: 946da224ea81449493723a3a29114d16
-    digest: shake256:1847233c40adc132c29cb391a9d2a5547928b1bff129e76e2e33ce818d324101b260c8905eaa7e9033bb7ce6b7c72d33d4cbef4c63cade38df0b2eb9fba2ea6d
+    commit: 853661eaef744ff99b612392f4d338a5
+    digest: shake256:9b095a7dfe6c4e591d41f974e48710a4471e6f1bdde0abf6b098ff875eb45945c1035b2e359b7166067f35f3589823ce385c377dd7825e74978465f492abb070
   - remote: buf.build
     owner: bufbuild
     repository: protovalidate
-    commit: 0de7443d03cf41228f8a9790b12b417e
-    digest: shake256:3c0676a73cef06439c107cb9560627354815adbc254976f807d645de7e2c1bf19d0438d5d56d5bc92465377e0d9315951e986fc6ced2871e450534b2b8c953b0
+    commit: 1baebb0a15184714854fa1ddfd22a29b
+    digest: shake256:ecd24ac37ca4f1ea65d816ae98e2a977e5004076ac957de9aedc0d4b517c66eaf3b7c8d6c7669ffd6e2eca5e8a5705372bed339ba47a608b37183ef1ee4f8baf
   - remote: buf.build
     owner: googleapis
     repository: googleapis
@@ -19,5 +19,5 @@ deps:
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: 048ae6ff94ca4476b3225904b1078fad
-    digest: shake256:e5250bf2d999516c02206d757502b902e406f35c099d0e869dc3e4f923f6870fe0805a9974c27df0695462937eae90cd4d9db90bb9a03489412560baa74a87b6
+    commit: 3f42134f4c564983838425bc43c7a65f
+    digest: shake256:3d11d4c0fe5e05fda0131afefbce233940e27f0c31c5d4e385686aea58ccd30f72053f61af432fa83f1fc11cda57f5f18ca3da26a29064f73c5a0d076bba8d92


### PR DESCRIPTION
This changes the request level validation. The previous version disallowed fetching all relations; this version addresses that and unifies get-relation with get-relations in terms of input handling rules.