### PR TITLE
Optional subject_relation in GetRelationsRequest

### DIFF
--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -518,7 +518,7 @@ message GetRelationsRequest {
         (google.api.field_behavior) = OPTIONAL
     ];
     // optional subject relation name
-    string subject_relation                                     = 6
+    optional string subject_relation                            = 6
     [
         (buf.validate.field) = {
             ignore_empty: true,

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -518,7 +518,7 @@ message GetRelationsRequest {
         (google.api.field_behavior) = OPTIONAL
     ];
     // optional subject relation name
-    optional string subject_relation                            = 6
+    string subject_relation                                     = 6
     [
         (buf.validate.field) = {
             ignore_empty: true,
@@ -535,6 +535,11 @@ message GetRelationsRequest {
     ];
     // materialize relation objects
     bool with_objects                                           = 7
+    [
+        (google.api.field_behavior) = OPTIONAL
+    ];
+    // only return relations that do not have a subject relation.
+    bool with_empty_subject_relation                            = 8
     [
         (google.api.field_behavior) = OPTIONAL
     ];


### PR DESCRIPTION
**Breaking change**
When searching for relations, there's a difference between:
* Not filtering on subject_relation, in which case matching relations are returned regardless of their subject_relation value.
* Filtering the results to only include relations that do not have a subject relation.

The existing definitions do not offer a way to distinguish between the two cases because the meaning of an empty string as the subject relation can only be one of the two options.

This change makes subject_relation an optional field in which an empty string is distinguishable from a null value.

This PR does not affect GetRelation and GetGraph where callers are expected to specify the kind of relation they're looking for. But in GetRelations, there should be a way to retrieve _all_ relations for a given object.