### PR TITLE
deprecated v2

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,36 +1,36 @@
-SHELL 	   	    := $(shell which bash)
+SHELL           := $(shell which bash)
     
-NO_COLOR   	    := \033[0m
-OK_COLOR   	    := \033[32;01m
-ERR_COLOR  	    := \033[31;01m
-WARN_COLOR 	    := \033[36;01m
-ATTN_COLOR 	    := \033[33;01m
+NO_COLOR   .    := \033[0m
+OK_COLOR   .    := \033[32;01m
+ERR_COLOR  .    := \033[31;01m
+WARN_COLOR .    := \033[36;01m
+ATTN_COLOR .    := \033[33;01m
 
-GOOS		    := $(shell go env GOOS)
-GOARCH		    := $(shell go env GOARCH)
-GOPRIVATE		:= "github.com/aserto-dev"
+GOOS            := $(shell go env GOOS)
+GOARCH          := $(shell go env GOARCH)
+GOPRIVATE       := "github.com/aserto-dev"
 
-VAULT_VERSION	:= 1.8.12
-SVU_VERSION 	:= 1.12.0
-WIRE_VERSION	:= 0.6.0
-BUF_VERSION 	:= 1.30.0
+BIN_DIR         := ./bin
+EXT_DIR         := ./.ext
+EXT_BIN_DIR     := ${EXT_DIR}/bin
+EXT_TMP_DIR     := ${EXT_DIR}/tmp
+
+VAULT_VERSION   := 1.8.12
+SVU_VERSION     := 1.12.0
+WIRE_VERSION    := 0.6.0
+BUF_VERSION     := 1.34.0
 
 PROJECT         := directory
-BUF_USER		:= $(shell vault kv get -field ASERTO_BUF_USER kv/buf.build)
-BUF_TOKEN		:= $(shell vault kv get -field ASERTO_BUF_TOKEN kv/buf.build)
-BUF_REPO		:= "buf.build/aserto-dev/${PROJECT}"
-BUF_LATEST		:= $(shell BUF_BETA_SUPPRESS_WARNINGS=1 buf beta registry tag list ${BUF_REPO} --format json --reverse | jq -r '.results[0].name')
-BUF_DEV_IMAGE	:= "${PROJECT}.bin"
+BUF_USER        := $(shell vault kv get -field ASERTO_BUF_USER kv/buf.build)
+BUF_TOKEN       := $(shell vault kv get -field ASERTO_BUF_TOKEN kv/buf.build)
+BUF_REPO        := "buf.build/aserto-dev/${PROJECT}"
+BUF_LATEST      := $(shell BUF_BETA_SUPPRESS_WARNINGS=1 ${EXT_BIN_DIR}/buf beta registry label list ${BUF_REPO} --format json --reverse | jq -r '.results[0].name')
+BUF_DEV_IMAGE   := "${PROJECT}.bin"
 PROTO_REPO      := "pb-${PROJECT}"
 
 GIT_ORG         := "https://github.com/aserto-dev"
 
 RELEASE_TAG	    := $$(svu)
-    
-BIN_DIR		    := ./bin
-EXT_DIR		    := ./.ext
-EXT_BIN_DIR	    := ${EXT_DIR}/bin
-EXT_TMP_DIR	    := ${EXT_DIR}/tmp
 
 .PHONY: deps
 deps: info install-vault install-buf install-svu
@@ -73,12 +73,12 @@ buf-mod-update:
 
 .PHONY: buf-generate
 buf-generate:
-	@echo -e "$(ATTN_COLOR)==> $@ $(NO_COLOR)"
+	@echo -e "$(ATTN_COLOR)==> $@ ${BUF_REPO}:${BUF_LATEST}$(NO_COLOR)"
 	@${EXT_BIN_DIR}/buf generate ${BUF_REPO}:${BUF_LATEST}
 
 .PHONY: buf-generate-dev
 buf-generate-dev:
-	@echo -e "$(ATTN_COLOR)==> $@ $(NO_COLOR)"
+	@echo -e "$(ATTN_COLOR)==> $@ ${BUF_DEV_IMAGE}$(NO_COLOR)"
 	@${EXT_BIN_DIR}/buf generate "../${PROTO_REPO}/${BUF_DEV_IMAGE}"
 
 .PHONY: info
@@ -108,7 +108,7 @@ install-vault: ${EXT_BIN_DIR} ${EXT_TMP_DIR}
 .PHONY: install-buf
 install-buf: ${EXT_BIN_DIR}
 	@echo -e "$(ATTN_COLOR)==> $@ $(NO_COLOR)"
-	@gh release download --repo https://github.com/bufbuild/buf --pattern "buf-$$(uname -s)-$$(uname -m)" --output "${EXT_BIN_DIR}/buf" --clobber
+	@gh release download v${BUF_VERSION} --repo https://github.com/bufbuild/buf --pattern "buf-$$(uname -s)-$$(uname -m)" --output "${EXT_BIN_DIR}/buf" --clobber
 	@chmod +x ${EXT_BIN_DIR}/buf
 	@${EXT_BIN_DIR}/buf --version
 

--- a/makefile
+++ b/makefile
@@ -1,10 +1,10 @@
 SHELL           := $(shell which bash)
     
-NO_COLOR   .    := \033[0m
-OK_COLOR   .    := \033[32;01m
-ERR_COLOR  .    := \033[31;01m
-WARN_COLOR .    := \033[36;01m
-ATTN_COLOR .    := \033[33;01m
+NO_COLOR       := \033[0m
+OK_COLOR        := \033[32;01m
+ERR_COLOR       := \033[31;01m
+WARN_COLOR      := \033[36;01m
+ATTN_COLOR      := \033[33;01m
 
 GOOS            := $(shell go env GOOS)
 GOARCH          := $(shell go env GOARCH)

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 SHELL           := $(shell which bash)
     
-NO_COLOR       := \033[0m
+NO_COLOR        := \033[0m
 OK_COLOR        := \033[32;01m
 ERR_COLOR       := \033[31;01m
 WARN_COLOR      := \033[36;01m

--- a/proto/aserto/directory/common/v2/common.proto
+++ b/proto/aserto/directory/common/v2/common.proto
@@ -8,6 +8,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 message ObjectType {
+    option deprecated = true; 
     reserved 1, 22;
     reserved "id", "deleted_at";
 
@@ -32,6 +33,7 @@ message ObjectType {
 }
 
 message Permission {
+    option deprecated = true; 
     reserved 1, 22;
     reserved "id", "deleted_at";
 
@@ -48,6 +50,7 @@ message Permission {
 }
 
 message RelationType {
+    option deprecated = true; 
     reserved 1, 22;
     reserved "id", "deleted_at";
 
@@ -74,6 +77,7 @@ message RelationType {
 }
 
 message Object {
+    option deprecated = true; 
     reserved 1, 22;
     reserved "id", "deleted_at";
 
@@ -94,6 +98,7 @@ message Object {
 }
 
 message Relation {
+    option deprecated = true; 
     reserved 22;
     reserved "deleted_at";
 
@@ -112,6 +117,7 @@ message Relation {
 }
 
 message ObjectDependency {
+    option deprecated = true; 
     reserved 3, 9;
     reserved "object_id", "subject_id";
 
@@ -134,6 +140,7 @@ message ObjectDependency {
 }
 
 enum Flag {
+    option deprecated = true; 
     // default, no special object behavior
     FLAG_UNKNOWN                                        = 0x0;
     // hidden object
@@ -148,6 +155,7 @@ enum Flag {
 
 // ObjectType identifier
 message ObjectTypeIdentifier {
+    option deprecated = true; 
     reserved 1;
     reserved "id";
 
@@ -157,6 +165,7 @@ message ObjectTypeIdentifier {
 
 // Permission identifier
 message PermissionIdentifier {
+    option deprecated = true; 
     reserved 1;
     reserved "id";
 
@@ -166,6 +175,7 @@ message PermissionIdentifier {
 
 // RelationType identifier
 message RelationTypeIdentifier {
+    option deprecated = true; 
     reserved 1;
     reserved "id";
 
@@ -177,6 +187,7 @@ message RelationTypeIdentifier {
 
 // Object identifier
 message ObjectIdentifier {
+    option deprecated = true; 
     reserved 2;
     reserved "id";
 
@@ -188,6 +199,7 @@ message ObjectIdentifier {
 
 // Relation identifier
 message RelationIdentifier {
+    option deprecated = true; 
     // subject identifier
     ObjectIdentifier subject                            = 1;
     // relation identifier
@@ -198,6 +210,7 @@ message RelationIdentifier {
 
 // Pagination request
 message PaginationRequest {
+    option deprecated = true; 
     // requested page size, valid value between 1-100 rows (default 100)
     int32 size                                          = 1;
     // pagination start token, default ""
@@ -206,6 +219,7 @@ message PaginationRequest {
 
 // Pagination response
 message PaginationResponse {
+    option deprecated = true; 
     // next page token, when empty there are no more pages to fetch
     string next_token                                   = 1;
     // result size of the page returned

--- a/proto/aserto/directory/exporter/v2/exporter.proto
+++ b/proto/aserto/directory/exporter/v2/exporter.proto
@@ -9,10 +9,13 @@ import "aserto/directory/common/v2/common.proto";
 import "google/protobuf/timestamp.proto";
 
 service Exporter {
-    rpc Export(ExportRequest) returns (stream ExportResponse) {};
+    rpc Export(ExportRequest) returns (stream ExportResponse) {
+        option deprecated = true; 
+    };
 }
 
 message ExportRequest {
+    option deprecated = true; 
     // data export options mask
     uint32 options                                              = 1;
     // start export from timestamp (UTC)
@@ -20,6 +23,7 @@ message ExportRequest {
 }
 
 message ExportResponse {
+    option deprecated = true;
     oneof msg {
         // object instance (data)
         aserto.directory.common.v2.Object object                = 2;
@@ -35,6 +39,7 @@ message ExportResponse {
 }
 
 enum Option {
+    option deprecated = true;
     // nothing selected (default initialization value)
     OPTION_UNKNOWN                                              = 0x0;
     // object type metadata

--- a/proto/aserto/directory/exporter/v3/exporter.proto
+++ b/proto/aserto/directory/exporter/v3/exporter.proto
@@ -10,6 +10,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 service Exporter {
+    // export objects and relations as a stream
     rpc Export(ExportRequest) returns (stream ExportResponse) {};
 }
 

--- a/proto/aserto/directory/importer/v2/importer.proto
+++ b/proto/aserto/directory/importer/v2/importer.proto
@@ -7,10 +7,13 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/importe
 import "aserto/directory/common/v2/common.proto";
 
 service Importer {
-    rpc Import(stream ImportRequest) returns (stream ImportResponse) {};
+    rpc Import(stream ImportRequest) returns (stream ImportResponse) {
+        option deprecated = true; 
+    };
 }
 
 message ImportRequest {
+    option deprecated = true;
     // operation Opcode enum value
     Opcode op_code                                              = 1;
     oneof msg {
@@ -28,6 +31,7 @@ message ImportRequest {
 }
 
 message ImportResponse {
+    option deprecated = true;
     // object_type import counter
     ImportCounter object_type                                   = 1;
     // object_type import counter
@@ -41,6 +45,7 @@ message ImportResponse {
 }
 
 message ImportCounter {
+    option deprecated = true;
     // number of messages received
     uint64 recv                                                 = 1;
     // number of messages with OPCODE_SET
@@ -52,6 +57,7 @@ message ImportCounter {
 }
 
 enum Opcode {
+    option deprecated = true;
     OPCODE_UNKNOWN                                              = 0;
     OPCODE_SET                                                  = 1;
     OPCODE_DELETE                                               = 2;

--- a/proto/aserto/directory/importer/v2/importer.proto
+++ b/proto/aserto/directory/importer/v2/importer.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/importe
 import "aserto/directory/common/v2/common.proto";
 
 service Importer {
+    // import stream of objects and relations
     rpc Import(stream ImportRequest) returns (stream ImportResponse) {
         option deprecated = true; 
     };

--- a/proto/aserto/directory/importer/v3/importer.proto
+++ b/proto/aserto/directory/importer/v3/importer.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/importe
 import "aserto/directory/common/v3/common.proto";
 
 service Importer {
+    // import stream of objects and relations
     rpc Import(stream ImportRequest) returns (stream ImportResponse) {};
 }
 

--- a/proto/aserto/directory/model/v3/model.proto
+++ b/proto/aserto/directory/model/v3/model.proto
@@ -15,6 +15,7 @@ import "buf/validate/validate.proto";
 // import "aserto/directory/common/v3/common.proto";
 
 service Model {
+    // get manifest instance
     rpc GetManifest(GetManifestRequest) returns (stream GetManifestResponse) {
         // Disable grpc-gateway for this rpc.
         option (google.api.http) = {};
@@ -46,6 +47,7 @@ service Model {
         // };
     };
 
+    // set manifest instance
     rpc SetManifest(stream SetManifestRequest) returns (SetManifestResponse) {
         // Disable grpc-gateway for this rpc.
         option (google.api.http) = {};
@@ -77,6 +79,7 @@ service Model {
         // };
     };
 
+    // delete manifest instance
     rpc DeleteManifest(DeleteManifestRequest) returns (DeleteManifestResponse) {
         option (google.api.http) = {
                 delete: "/api/v3/directory/manifest"

--- a/proto/aserto/directory/reader/v2/reader.proto
+++ b/proto/aserto/directory/reader/v2/reader.proto
@@ -8,52 +8,90 @@ import "aserto/directory/common/v2/common.proto";
 
 service Reader {
     // object type metadata methods
-    rpc GetObjectType(GetObjectTypeRequest) returns (GetObjectTypeResponse) {};
-    rpc GetObjectTypes(GetObjectTypesRequest) returns (GetObjectTypesResponse) {};
+    rpc GetObjectType(GetObjectTypeRequest) returns (GetObjectTypeResponse) {
+        option deprecated = true; 
+    };
+    rpc GetObjectTypes(GetObjectTypesRequest) returns (GetObjectTypesResponse) {
+        option deprecated = true; 
+    };
 
     // relation type metadata methods
-    rpc GetRelationType(GetRelationTypeRequest) returns (GetRelationTypeResponse) {};
-    rpc GetRelationTypes(GetRelationTypesRequest) returns (GetRelationTypesResponse) {};
+    rpc GetRelationType(GetRelationTypeRequest) returns (GetRelationTypeResponse) {
+        option deprecated = true; 
+    };
+    rpc GetRelationTypes(GetRelationTypesRequest) returns (GetRelationTypesResponse) {
+        option deprecated = true; 
+    };
 
     // permission metadata methods
-    rpc GetPermission(GetPermissionRequest) returns (GetPermissionResponse) {};
-    rpc GetPermissions(GetPermissionsRequest) returns (GetPermissionsResponse) {};
+    rpc GetPermission(GetPermissionRequest) returns (GetPermissionResponse) {
+        option deprecated = true; 
+    };
+    rpc GetPermissions(GetPermissionsRequest) returns (GetPermissionsResponse) {
+        option deprecated = true; 
+    };
 
     // object methods
-    rpc GetObject(GetObjectRequest) returns (GetObjectResponse) {};
-    rpc GetObjectMany(GetObjectManyRequest) returns (GetObjectManyResponse) {};
-    rpc GetObjects(GetObjectsRequest) returns (GetObjectsResponse) {};
+    // GetObject
+    // Deprecated: directory.v2.GetObject is deprecated, update to use directory.v3.GetObject.
+    rpc GetObject(GetObjectRequest) returns (GetObjectResponse) {
+        option deprecated = true; 
+    };
+    // GetObjectMany
+    // Deprecated: directory.v2.GetObjectMany is deprecated, update to use directory.v3.GetObjectMany.
+    rpc GetObjectMany(GetObjectManyRequest) returns (GetObjectManyResponse) {
+        option deprecated = true; 
+    };
+    // GetObjects
+    // Deprecated: directory.v2.GetObjects is deprecated, update to use directory.v3.GetObjects.
+    rpc GetObjects(GetObjectsRequest) returns (GetObjectsResponse) {
+        option deprecated = true; 
+    };
 
     // relation methods
-    rpc GetRelation(GetRelationRequest) returns (GetRelationResponse) {};
-    rpc GetRelations(GetRelationsRequest) returns (GetRelationsResponse) {};
+    rpc GetRelation(GetRelationRequest) returns (GetRelationResponse) {
+        option deprecated = true; 
+    };
+    rpc GetRelations(GetRelationsRequest) returns (GetRelationsResponse) {
+        option deprecated = true; 
+    };
 
     // check permission method
-    rpc CheckPermission(CheckPermissionRequest) returns (CheckPermissionResponse) {};
+    rpc CheckPermission(CheckPermissionRequest) returns (CheckPermissionResponse) {
+        option deprecated = true; 
+    };
 
     // check relation method
-    rpc CheckRelation(CheckRelationRequest) returns (CheckRelationResponse) {};
+    rpc CheckRelation(CheckRelationRequest) returns (CheckRelationResponse) {
+        option deprecated = true; 
+    };
 
     // graph methods
-    rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {};
+    rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {
+        option deprecated = true; 
+    };
 }
 
 message GetObjectTypeRequest {
+    option deprecated = true;
     // object type selector
     aserto.directory.common.v2.ObjectTypeIdentifier param       = 1;
 }
 
 message GetObjectTypeResponse {
+    option deprecated = true;
     // object type instance
     aserto.directory.common.v2.ObjectType result                = 1;
 }
 
 message GetObjectTypesRequest {
+    option deprecated = true;
     // pagination request
     aserto.directory.common.v2.PaginationRequest page           = 9;
 }
 
 message GetObjectTypesResponse {
+    option deprecated = true;
     // array of object types
     repeated aserto.directory.common.v2.ObjectType results      = 1;
     // pagination response
@@ -61,16 +99,19 @@ message GetObjectTypesResponse {
 }
 
 message GetRelationTypeRequest {
+    option deprecated = true;
     // relation type selector
     aserto.directory.common.v2.RelationTypeIdentifier param     = 1;
 }
 
 message GetRelationTypeResponse {
+    option deprecated = true;
     // relation type instance
     aserto.directory.common.v2.RelationType result              = 1;
 }
 
 message GetRelationTypesRequest {
+    option deprecated = true;
     // object type selector
     aserto.directory.common.v2.ObjectTypeIdentifier param       = 1;
     // pagination request
@@ -78,6 +119,7 @@ message GetRelationTypesRequest {
 }
 
 message GetRelationTypesResponse {
+    option deprecated = true;
     // array of relation types
     repeated aserto.directory.common.v2.RelationType results    = 1;
     // pagination response
@@ -85,6 +127,7 @@ message GetRelationTypesResponse {
 }
 
 message GetObjectRequest {
+    option deprecated = true;
     // object selector
     aserto.directory.common.v2.ObjectIdentifier param           = 1;
     // materialize the object relations objects
@@ -94,6 +137,7 @@ message GetObjectRequest {
 }
 
 message GetObjectResponse {
+    option deprecated = true;
     reserved 2, 3;
     reserved "incoming", "outgoing";
     // object instance
@@ -105,16 +149,19 @@ message GetObjectResponse {
 }
 
 message GetObjectManyRequest {
+    option deprecated = true;
     // object identifier list
     repeated aserto.directory.common.v2.ObjectIdentifier param  = 1;
 }
 
 message GetObjectManyResponse {
+    option deprecated = true;
     // array of object instances
     repeated aserto.directory.common.v2.Object results          = 1;
 }
 
 message GetObjectsRequest {
+    option deprecated = true;
     // object type selector
     aserto.directory.common.v2.ObjectTypeIdentifier param       = 1;
     // pagination request
@@ -122,6 +169,7 @@ message GetObjectsRequest {
 }
 
 message GetObjectsResponse {
+    option deprecated = true;
     // array of object instances
     repeated aserto.directory.common.v2.Object results          = 1;
     // pagination response
@@ -129,6 +177,7 @@ message GetObjectsResponse {
 }
 
 message GetRelationRequest {
+    option deprecated = true;
     // relation selector
     aserto.directory.common.v2.RelationIdentifier param         = 1;
     // materialize relation objects
@@ -136,6 +185,7 @@ message GetRelationRequest {
 }
 
 message GetRelationResponse {
+    option deprecated = true;
     // array of relation instances
     repeated aserto.directory.common.v2.Relation results        = 1;
     // map of materialized relation objects
@@ -143,6 +193,7 @@ message GetRelationResponse {
 }
 
 message GetRelationsRequest {
+    option deprecated = true;
     // relation selector
     aserto.directory.common.v2.RelationIdentifier param         = 1;
     // pagination request
@@ -150,6 +201,7 @@ message GetRelationsRequest {
 }
 
 message GetRelationsResponse {
+    option deprecated = true;
     // array of relation instances
     repeated aserto.directory.common.v2.Relation results        = 1;
     // pagination response
@@ -157,21 +209,25 @@ message GetRelationsResponse {
 }
 
 message GetPermissionRequest {
+    option deprecated = true;
     // permission selector
     aserto.directory.common.v2.PermissionIdentifier param       = 1;
 }
 
 message GetPermissionResponse {
+    option deprecated = true;
     // permission instance
     aserto.directory.common.v2.Permission result                = 1;
 }
 
 message GetPermissionsRequest {
+    option deprecated = true;
     // pagination request
     aserto.directory.common.v2.PaginationRequest page           = 9;
 }
 
 message GetPermissionsResponse {
+    option deprecated = true;
     // array of permissions
     repeated aserto.directory.common.v2.Permission results      = 1;
     // pagination response
@@ -179,6 +235,7 @@ message GetPermissionsResponse {
 }
 
 message CheckPermissionRequest {
+    option deprecated = true;
     // subject selector
     aserto.directory.common.v2.ObjectIdentifier subject         = 1;
     // permission selector
@@ -190,6 +247,7 @@ message CheckPermissionRequest {
 }
 
 message CheckPermissionResponse {
+    option deprecated = true;
     // check result
     bool check                                                  = 1;
     // trace information
@@ -197,6 +255,7 @@ message CheckPermissionResponse {
 }
 
 message CheckRelationRequest {
+    option deprecated = true;
     // subject selector
     aserto.directory.common.v2.ObjectIdentifier subject         = 1;
     // relation selector
@@ -208,6 +267,7 @@ message CheckRelationRequest {
 }
 
 message CheckRelationResponse {
+    option deprecated = true;
     // check result
     bool check                                                  = 1;
     // trace information
@@ -215,6 +275,7 @@ message CheckRelationResponse {
 }
 
 message CheckResponse {
+    option deprecated = true;
     // check result
     bool check                                                  = 1;
     // trace information
@@ -222,6 +283,7 @@ message CheckResponse {
 }
 
 message GetGraphRequest {
+    option deprecated = true;
     // anchor selector
     aserto.directory.common.v2.ObjectIdentifier anchor          = 1;
     // subject selector
@@ -233,6 +295,7 @@ message GetGraphRequest {
 }
 
 message GetGraphResponse {
+    option deprecated = true;
     // dependency graph
     repeated aserto.directory.common.v2.ObjectDependency results= 1;
 }

--- a/proto/aserto/directory/reader/v2/reader.proto
+++ b/proto/aserto/directory/reader/v2/reader.proto
@@ -7,66 +7,74 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/reader/
 import "aserto/directory/common/v2/common.proto";
 
 service Reader {
-    // object type metadata methods
+    // get object type metadata
     rpc GetObjectType(GetObjectTypeRequest) returns (GetObjectTypeResponse) {
         option deprecated = true; 
     };
+    // list object type metadata
     rpc GetObjectTypes(GetObjectTypesRequest) returns (GetObjectTypesResponse) {
         option deprecated = true; 
     };
 
-    // relation type metadata methods
+    // get relation type metadata
     rpc GetRelationType(GetRelationTypeRequest) returns (GetRelationTypeResponse) {
         option deprecated = true; 
     };
+    // list relation type metadata
     rpc GetRelationTypes(GetRelationTypesRequest) returns (GetRelationTypesResponse) {
         option deprecated = true; 
     };
 
-    // permission metadata methods
+    // get permission metadata
     rpc GetPermission(GetPermissionRequest) returns (GetPermissionResponse) {
         option deprecated = true; 
     };
+    // list permission metadata
     rpc GetPermissions(GetPermissionsRequest) returns (GetPermissionsResponse) {
         option deprecated = true; 
     };
 
-    // object methods
-    // GetObject
-    // Deprecated: directory.v2.GetObject is deprecated, update to use directory.v3.GetObject.
+    // get object 
+    // Deprecated: directory.v2.GetObject is deprecated, use directory.v3.GetObject.
     rpc GetObject(GetObjectRequest) returns (GetObjectResponse) {
         option deprecated = true; 
     };
-    // GetObjectMany
+    // get multiple objects
     // Deprecated: directory.v2.GetObjectMany is deprecated, update to use directory.v3.GetObjectMany.
     rpc GetObjectMany(GetObjectManyRequest) returns (GetObjectManyResponse) {
         option deprecated = true; 
     };
-    // GetObjects
+    // list objects
     // Deprecated: directory.v2.GetObjects is deprecated, update to use directory.v3.GetObjects.
     rpc GetObjects(GetObjectsRequest) returns (GetObjectsResponse) {
         option deprecated = true; 
     };
 
-    // relation methods
+    // get relation
+    // Deprecated: directory.v2.GetRelation is deprecated, update to use directory.v3.GetRelation.
     rpc GetRelation(GetRelationRequest) returns (GetRelationResponse) {
         option deprecated = true; 
     };
+    // list relations
+    // Deprecated: directory.v2.GetRelations is deprecated, update to use directory.v3.GetRelations.
     rpc GetRelations(GetRelationsRequest) returns (GetRelationsResponse) {
         option deprecated = true; 
     };
 
-    // check permission method
+    // check permission
+    // Deprecated: directory.v2.CheckPermission is deprecated, update to use directory.v3.Check.
     rpc CheckPermission(CheckPermissionRequest) returns (CheckPermissionResponse) {
         option deprecated = true; 
     };
 
-    // check relation method
+    // check relation
+    // Deprecated: directory.v2.CheckRelation is deprecated, update to use directory.v3.Check.
     rpc CheckRelation(CheckRelationRequest) returns (CheckRelationResponse) {
         option deprecated = true; 
     };
 
-    // graph methods
+    // get object relationship graph
+    // Deprecated: directory.v2.GetGraph is deprecated, update to use directory.v3.GetGraph.
     rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {
         option deprecated = true; 
     };

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -14,7 +14,7 @@ import "buf/validate/validate.proto";
 import "aserto/directory/common/v3/common.proto";
 
 service Reader {
-    // object methods
+    // get object
     rpc GetObject(GetObjectRequest) returns (GetObjectResponse) {
         option (google.api.http) = {
             get: "/api/v3/directory/object/{object_type}/{object_id}"
@@ -44,8 +44,10 @@ service Reader {
         };
     };
 
+    // get multiple objects
     rpc GetObjectMany(GetObjectManyRequest) returns (GetObjectManyResponse) {};
 
+    // list objects
     rpc GetObjects(GetObjectsRequest) returns (GetObjectsResponse) {
         option (google.api.http) = {
             get: "/api/v3/directory/objects"
@@ -69,7 +71,7 @@ service Reader {
         };
     };
 
-    // relation methods
+    // get relation
     rpc GetRelation(GetRelationRequest) returns (GetRelationResponse) {
         option (google.api.http) = {
             get: "/api/v3/directory/relation"
@@ -99,6 +101,7 @@ service Reader {
         };
     };
 
+    // list relations
     rpc GetRelations(GetRelationsRequest) returns (GetRelationsResponse) {
         option (google.api.http) = {
             get: "/api/v3/directory/relations"
@@ -122,7 +125,7 @@ service Reader {
         };
     };
 
-    // check method
+    // check if subject has relation or permission with object
     rpc Check(CheckRequest) returns (CheckResponse) {
         option (google.api.http) = {
             post: "/api/v3/directory/check"
@@ -147,8 +150,8 @@ service Reader {
         };
     };
 
-    // check permission method
-    // deprecated: use directory.v3.Check()
+    // check permission (deprecated, use the check method)
+    // Deprecated: use directory.v3.Check()
     rpc CheckPermission(CheckPermissionRequest) returns (CheckPermissionResponse) {
         option deprecated = true;
         option (google.api.http) = {
@@ -174,8 +177,8 @@ service Reader {
         };
     };
 
-    // check relation method
-    // deprecated: use directory.v3.Check()
+    // check relation (deprecated, use the check method)
+    // Deprecated: use directory.v3.Check()
     rpc CheckRelation(CheckRelationRequest) returns (CheckRelationResponse) {
         option deprecated = true;
         option (google.api.http) = {
@@ -201,7 +204,7 @@ service Reader {
         };
     };
 
-    // graph methods
+    // get object relationship graph
     rpc GetGraph(GetGraphRequest) returns (GetGraphResponse) {
         option (google.api.http) = {
             get: "/api/v3/directory/graph/{object_type}/{relation}/{subject_type}"

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -148,7 +148,9 @@ service Reader {
     };
 
     // check permission method
+    // deprecated: use directory.v3.Check()
     rpc CheckPermission(CheckPermissionRequest) returns (CheckPermissionResponse) {
+        option deprecated = true;
         option (google.api.http) = {
             post: "/api/v3/directory/check/permission"
             body: "*"
@@ -173,7 +175,9 @@ service Reader {
     };
 
     // check relation method
+    // deprecated: use directory.v3.Check()
     rpc CheckRelation(CheckRelationRequest) returns (CheckRelationResponse) {
+        option deprecated = true;
         option (google.api.http) = {
             post: "/api/v3/directory/check/relation"
             body: "*"

--- a/proto/aserto/directory/schema/v2/group.proto
+++ b/proto/aserto/directory/schema/v2/group.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/schema/
 
 // Properties of "group" objects.
 message GroupProperties {
+    option deprecated = true;
     // ID of the IDP connection the group instance is associated with.
     string connection_id = 1;
 }

--- a/proto/aserto/directory/schema/v2/identity.proto
+++ b/proto/aserto/directory/schema/v2/identity.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/schema/
 
 // Properties of "identity" objects.
 message IdentityProperties {
+    option deprecated = true;
     // identity kind [email|username|uid|pid|dn|phone]
     IdentityKind kind                       = 1;
     // identity provider name
@@ -17,6 +18,7 @@ message IdentityProperties {
 }
 
 enum IdentityKind {
+    option deprecated = true;
     // undefined state
     IDENTITY_KIND_UNKNOWN                   = 0;
     // provider unique identifier

--- a/proto/aserto/directory/schema/v2/tenant.proto
+++ b/proto/aserto/directory/schema/v2/tenant.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/schema/
 import "google/protobuf/struct.proto";
 
 enum TenantKind {
+  option deprecated = true;
   TENANT_KIND_UNKNOWN = 0;
   TENANT_KIND_ORGANIZATION = 1;
   TENANT_KIND_ACCOUNT = 2;  // personal tenant
@@ -14,6 +15,7 @@ enum TenantKind {
 
 // Properties of a tenant object
 message TenantProperties {
+  option deprecated = true;
   // The kind of tenant.
   TenantKind kind = 1;
 
@@ -29,6 +31,7 @@ message TenantProperties {
 }
 
 message AccountProperties {
+  option deprecated = true;
   // Maximum number of organizations that can be created in this account.
   // If -1, there is no limit.
   int32 max_orgs = 1;
@@ -42,6 +45,7 @@ message AccountProperties {
 
 // The state of a user's progress through the console's getting started guide.
 message GuideState {
+  option deprecated = true;
   // Whether or not to display the getting started guide.
   bool show = 1;
 

--- a/proto/aserto/directory/schema/v2/user.proto
+++ b/proto/aserto/directory/schema/v2/user.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/aserto-dev/go-directory/aserto/directory/schema/
 
 // Properties of "user" objects.
 message UserProperties {
+    option deprecated = true;
     // main email address of user
     string email                            = 1;
     // URL to user's picture
@@ -19,6 +20,7 @@ message UserProperties {
 }
 
 enum UserStatus {
+    option deprecated = true;
     // User status undefined
     USER_STATUS_UNKNOWN                     = 0;
     // Staged status, is when the user object is first created, before the activation flow is initiated, or if there is a pending admin action.

--- a/proto/aserto/directory/writer/v2/writer.proto
+++ b/proto/aserto/directory/writer/v2/writer.proto
@@ -9,7 +9,6 @@ import "google/protobuf/empty.proto";
 import "aserto/directory/common/v2/common.proto";
 
 service Writer {
-    // object type metadata methods
     rpc SetObjectType(SetObjectTypeRequest) returns (SetObjectTypeResponse) {
         option deprecated = true; 
     };
@@ -17,7 +16,6 @@ service Writer {
         option deprecated = true; 
     };
 
-    // relation type metadata methods
     rpc SetRelationType(SetRelationTypeRequest) returns (SetRelationTypeResponse) {
         option deprecated = true; 
     };
@@ -25,7 +23,6 @@ service Writer {
         option deprecated = true; 
     };
 
-    // permission metadata methods
     rpc SetPermission(SetPermissionRequest) returns (SetPermissionResponse) {
         option deprecated = true; 
     };
@@ -33,18 +30,25 @@ service Writer {
         option deprecated = true; 
     };
 
-    // object methods
+    // set object instance
+    // Deprecated: directory.v2.SetObject is deprecated, use directory.v3.SetObject.
     rpc SetObject(SetObjectRequest) returns (SetObjectResponse) {
         option deprecated = true; 
     };
+
+    // delete object instance
+    // Deprecated: directory.v2.DeleteObject is deprecated, use directory.v3.DeleteObject.
     rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {
         option deprecated = true; 
     };
 
-    // relation methods
+    // set relation instance
+    // Deprecated: directory.v2.SetRelation is deprecated, use directory.v3.SetRelation.
     rpc SetRelation(SetRelationRequest) returns (SetRelationResponse) {
         option deprecated = true; 
     };
+    // delete relation instance
+    // Deprecated: directory.v2.DeleteRelation is deprecated, use directory.v3.DeleteRelation.
     rpc DeleteRelation(DeleteRelationRequest) returns (DeleteRelationResponse) {
         option deprecated = true; 
     };

--- a/proto/aserto/directory/writer/v2/writer.proto
+++ b/proto/aserto/directory/writer/v2/writer.proto
@@ -10,97 +10,132 @@ import "aserto/directory/common/v2/common.proto";
 
 service Writer {
     // object type metadata methods
-    rpc SetObjectType(SetObjectTypeRequest) returns (SetObjectTypeResponse) {};
-    rpc DeleteObjectType(DeleteObjectTypeRequest) returns (DeleteObjectTypeResponse) {};
+    rpc SetObjectType(SetObjectTypeRequest) returns (SetObjectTypeResponse) {
+        option deprecated = true; 
+    };
+    rpc DeleteObjectType(DeleteObjectTypeRequest) returns (DeleteObjectTypeResponse) {
+        option deprecated = true; 
+    };
 
     // relation type metadata methods
-    rpc SetRelationType(SetRelationTypeRequest) returns (SetRelationTypeResponse) {};
-    rpc DeleteRelationType(DeleteRelationTypeRequest) returns (DeleteRelationTypeResponse) {};
+    rpc SetRelationType(SetRelationTypeRequest) returns (SetRelationTypeResponse) {
+        option deprecated = true; 
+    };
+    rpc DeleteRelationType(DeleteRelationTypeRequest) returns (DeleteRelationTypeResponse) {
+        option deprecated = true; 
+    };
 
     // permission metadata methods
-    rpc SetPermission(SetPermissionRequest) returns (SetPermissionResponse) {};
-    rpc DeletePermission(DeletePermissionRequest) returns (DeletePermissionResponse) {};
+    rpc SetPermission(SetPermissionRequest) returns (SetPermissionResponse) {
+        option deprecated = true; 
+    };
+    rpc DeletePermission(DeletePermissionRequest) returns (DeletePermissionResponse) {
+        option deprecated = true; 
+    };
 
     // object methods
-    rpc SetObject(SetObjectRequest) returns (SetObjectResponse) {};
-    rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {};
+    rpc SetObject(SetObjectRequest) returns (SetObjectResponse) {
+        option deprecated = true; 
+    };
+    rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {
+        option deprecated = true; 
+    };
 
     // relation methods
-    rpc SetRelation(SetRelationRequest) returns (SetRelationResponse) {};
-    rpc DeleteRelation(DeleteRelationRequest) returns (DeleteRelationResponse) {};
+    rpc SetRelation(SetRelationRequest) returns (SetRelationResponse) {
+        option deprecated = true; 
+    };
+    rpc DeleteRelation(DeleteRelationRequest) returns (DeleteRelationResponse) {
+        option deprecated = true; 
+    };
 }
 
 message SetObjectTypeRequest {
+    option deprecated = true;
     // object type instance
     aserto.directory.common.v2.ObjectType object_type           = 1;
 }
 
 message SetObjectTypeResponse {
+    option deprecated = true;
     // object type instance
     aserto.directory.common.v2.ObjectType result                = 1;
 }
 
 message DeleteObjectTypeRequest {
+    option deprecated = true;
     // object type identifier
     aserto.directory.common.v2.ObjectTypeIdentifier param       = 1;
 }
 
 message DeleteObjectTypeResponse {
+    option deprecated = true;
     // empty result
     google.protobuf.Empty result                                = 1;
 }
 
 message SetRelationTypeRequest {
+    option deprecated = true;
     // relation type instance
     aserto.directory.common.v2.RelationType relation_type       = 1;
 }
 
 message SetRelationTypeResponse {
+    option deprecated = true;
     // relation types instance
     aserto.directory.common.v2.RelationType result              = 1;
 }
 
 message DeleteRelationTypeRequest {
+    option deprecated = true;
     // relation type identifier
     aserto.directory.common.v2.RelationTypeIdentifier param     = 1;
 }
 
 message DeleteRelationTypeResponse {
+    option deprecated = true;
     // empty result
     google.protobuf.Empty result                                = 1;
 }
 
 message SetPermissionRequest {
+    option deprecated = true;
     // permission instance
     aserto.directory.common.v2.Permission permission            = 1;
 }
 
 message SetPermissionResponse {
+    option deprecated = true;
     // permission instance
     aserto.directory.common.v2.Permission result                = 1;
 }
 
 message DeletePermissionRequest {
+    option deprecated = true;
     // permission identifier
     aserto.directory.common.v2.PermissionIdentifier param       = 1;
 }
 
 message DeletePermissionResponse {
+    option deprecated = true;
     // empty result
     google.protobuf.Empty result                                = 1;
 }
 
 message SetObjectRequest {
+    option deprecated = true;
     // object instance
     aserto.directory.common.v2.Object object                    = 1;
 }
 
 message SetObjectResponse {
+    option deprecated = true;
     // object instance
     aserto.directory.common.v2.Object result                    = 1;
 }
 
 message DeleteObjectRequest {
+    option deprecated = true;
     // object identifier
     aserto.directory.common.v2.ObjectIdentifier param           = 1;
     // delete object relations, both object and subject relations.
@@ -108,26 +143,31 @@ message DeleteObjectRequest {
 }
 
 message DeleteObjectResponse {
+    option deprecated = true;
     // empty result
     google.protobuf.Empty result                                = 1;
 }
 
 message SetRelationRequest {
+    option deprecated = true;
     // relation instance
     aserto.directory.common.v2.Relation relation                = 1;
 }
 
 message SetRelationResponse {
+    option deprecated = true;
     // relation instance
     aserto.directory.common.v2.Relation result                  = 1;
 }
 
 message DeleteRelationRequest {
+    option deprecated = true;
     // relation identifier
     aserto.directory.common.v2.RelationIdentifier param         = 1;
 }
 
 message DeleteRelationResponse {
+    option deprecated = true;
     // empty result
     google.protobuf.Empty result                                = 1;
 }

--- a/proto/aserto/directory/writer/v3/writer.proto
+++ b/proto/aserto/directory/writer/v3/writer.proto
@@ -14,7 +14,7 @@ import "buf/validate/validate.proto";
 import "aserto/directory/common/v3/common.proto";
 
 service Writer {
-    // object methods
+    // set object instance
     rpc SetObject(SetObjectRequest) returns (SetObjectResponse) {
         option (google.api.http) = {
             post: "/api/v3/directory/object"
@@ -39,6 +39,7 @@ service Writer {
         };
     };
 
+    // delete object instance
     rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {
         option (google.api.http) = {
             delete: "/api/v3/directory/object/{object_type}/{object_id}"
@@ -62,7 +63,7 @@ service Writer {
         };
     };
 
-    // relation methods
+    // set relation instance
     rpc SetRelation(SetRelationRequest) returns (SetRelationResponse) {
         option (google.api.http) = {
             post: "/api/v3/directory/relation"
@@ -87,6 +88,7 @@ service Writer {
         };
     };
 
+    // delete relation instance
     rpc DeleteRelation(DeleteRelationRequest) returns (DeleteRelationResponse) {
         option (google.api.http) = {
             delete: "/api/v3/directory/relation"


### PR DESCRIPTION
* mark all directory v2 methods, messages and enums as deprecated
  * `option deprecated = true;`
* mark the directory v3 `CheckPermission` and `CheckRelation` as deprecated methods, and to use directory. v3.Check instead
  * option deprecated = true;
  * added comment: deprecated: use directory.v3.Check()
* update makefile
  * update to buf 1.34.0
  * fix make issues