### PR TITLE
add context to check response

### DIFF
--- a/proto/aserto/directory/assertion/v3/assertion.proto
+++ b/proto/aserto/directory/assertion/v3/assertion.proto
@@ -174,4 +174,7 @@ message Assert {
         aserto.directory.reader.v3.CheckRelationRequest check_relation = 4;
         aserto.directory.reader.v3.CheckPermissionRequest check_permission = 5;
     }
+
+    // description
+    string description                                          = 6;
 }

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -681,6 +681,8 @@ message CheckResponse {
     bool check                                                  = 1;
     // trace information
     repeated string trace                                       = 2;
+    // context
+    google.protobuf.Struct context                              = 3;
 }
 
 message CheckPermissionRequest {


### PR DESCRIPTION
Add a `context` property to the `CheckResponse` message to relay the `reason` and other feedback; this implies that the `Check` function will never return an error based on the payload, it will return decision = false with a reason.