### PR TITLE
limit display_name and etag length

### DIFF
--- a/proto/aserto/directory/common/v3/common.proto
+++ b/proto/aserto/directory/common/v3/common.proto
@@ -46,6 +46,11 @@ message Object {
     // display name object
     string display_name                                 = 3
     [
+        (buf.validate.field) = {
+            string: {
+                max_len: 100
+            }
+        },
         (google.api.field_behavior) = OPTIONAL
     ];
     // property bag
@@ -66,6 +71,11 @@ message Object {
     // object instance etag
     string etag                                         = 23
     [
+        (buf.validate.field) = {
+            string: {
+                max_len: 20
+            }
+        },
         (google.api.field_behavior) = OPTIONAL
     ];
 }
@@ -180,6 +190,11 @@ message Relation {
     // object instance etag
     string etag                                         = 23
     [
+        (buf.validate.field) = {
+            string: {
+                max_len: 20
+            }
+        },
         (google.api.field_behavior) = OPTIONAL
     ];
 }


### PR DESCRIPTION
Limit the `display_name` and `etag` fields, respectively, to 100 and 20 characters max_len.