### PR TITLE
upd type identifier to support mixed case letters

### DIFF
--- a/proto/aserto/directory/common/v3/common.proto
+++ b/proto/aserto/directory/common/v3/common.proto
@@ -89,7 +89,7 @@ message Relation {
             cel: {
                 id: "relation.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -121,7 +121,7 @@ message Relation {
             cel: {
                 id: "relation.relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -137,7 +137,7 @@ message Relation {
             cel: {
                 id: "relation.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -169,7 +169,7 @@ message Relation {
             cel: {
                 id: "relation.subject_relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -209,7 +209,7 @@ message ObjectIdentifier {
             cel: {
                 id: "object_identifier.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -245,7 +245,7 @@ message RelationIdentifier {
             cel: {
                 id: "relation_identifier.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -277,7 +277,7 @@ message RelationIdentifier {
             cel: {
                 id: "relation_identifier.relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -293,7 +293,7 @@ message RelationIdentifier {
             cel: {
                 id: "relation_identifier.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -325,7 +325,7 @@ message RelationIdentifier {
             cel: {
                 id: "relation_identifier.subject_relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64

--- a/proto/aserto/directory/common/v3/common.proto
+++ b/proto/aserto/directory/common/v3/common.proto
@@ -18,8 +18,8 @@ message Object {
             required: true,
             cel: {
                 id: "object.type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -88,8 +88,8 @@ message Relation {
             required: true,
             cel: {
                 id: "relation.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -120,8 +120,8 @@ message Relation {
             required: true,
             cel: {
                 id: "relation.relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -136,8 +136,8 @@ message Relation {
             required: true,
             cel: {
                 id: "relation.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -168,8 +168,8 @@ message Relation {
             ignore_empty: true,
             cel: {
                 id: "relation.subject_relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -208,8 +208,8 @@ message ObjectIdentifier {
             required: true,
             cel: {
                 id: "object_identifier.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -244,8 +244,8 @@ message RelationIdentifier {
             ignore_empty: true,
             cel: {
                 id: "relation_identifier.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -276,8 +276,8 @@ message RelationIdentifier {
             ignore_empty: true,
             cel: {
                 id: "relation_identifier.relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -292,8 +292,8 @@ message RelationIdentifier {
             ignore_empty: true,
             cel: {
                 id: "relation_identifier.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -324,8 +324,8 @@ message RelationIdentifier {
             ignore_empty: true,
             cel: {
                 id: "relation_identifier.subject_relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -264,7 +264,7 @@ message GetObjectRequest {
             cel: {
                 id: "get_object.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -330,7 +330,7 @@ message GetObjectsRequest {
             cel: {
                 id: "get_objects.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -361,7 +361,7 @@ message GetRelationRequest {
             cel: {
                 id: "get_relation.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -393,7 +393,7 @@ message GetRelationRequest {
             cel: {
                 id: "get_relation.relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -409,7 +409,7 @@ message GetRelationRequest {
             cel: {
                 id: "get_relation.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -441,7 +441,7 @@ message GetRelationRequest {
             cel: {
                 id: "get_relation.subject_relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -486,7 +486,7 @@ message GetRelationsRequest {
             cel: {
                 id: "get_relations.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -518,7 +518,7 @@ message GetRelationsRequest {
             cel: {
                 id: "get_relations.relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -534,7 +534,7 @@ message GetRelationsRequest {
             cel: {
                 id: "get_relations.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -566,7 +566,7 @@ message GetRelationsRequest {
             cel: {
                 id: "get_relations.subject_relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -623,7 +623,7 @@ message CheckRequest {
             cel: {
                 id: "check.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -671,7 +671,7 @@ message CheckRequest {
             cel: {
                 id: "check.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -731,7 +731,7 @@ message CheckPermissionRequest {
             cel: {
                 id: "check_permission.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -779,7 +779,7 @@ message CheckPermissionRequest {
             cel: {
                 id: "check_permission.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -826,7 +826,7 @@ message CheckRelationRequest {
             cel: {
                 id: "check_relation.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -858,7 +858,7 @@ message CheckRelationRequest {
             cel: {
                 id: "check_relation.relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -874,7 +874,7 @@ message CheckRelationRequest {
             cel: {
                 id: "check_relation.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -924,7 +924,7 @@ message GetGraphRequest {
             cel: {
                 id: "get_graph.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -956,7 +956,7 @@ message GetGraphRequest {
             cel: {
                 id: "get_graph.relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -972,7 +972,7 @@ message GetGraphRequest {
             cel: {
                 id: "get_graph.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -1004,7 +1004,7 @@ message GetGraphRequest {
             cel: {
                 id: "get_graph.subject_relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64

--- a/proto/aserto/directory/reader/v3/reader.proto
+++ b/proto/aserto/directory/reader/v3/reader.proto
@@ -263,8 +263,8 @@ message GetObjectRequest {
             required: true
             cel: {
                 id: "get_object.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -329,8 +329,8 @@ message GetObjectsRequest {
             ignore_empty: true,
             cel: {
                 id: "get_objects.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -360,8 +360,8 @@ message GetRelationRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relation.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -392,8 +392,8 @@ message GetRelationRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relation.relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -408,8 +408,8 @@ message GetRelationRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relation.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -440,8 +440,8 @@ message GetRelationRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relation.subject_relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -485,8 +485,8 @@ message GetRelationsRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relations.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -517,8 +517,8 @@ message GetRelationsRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relations.relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -533,8 +533,8 @@ message GetRelationsRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relations.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -565,8 +565,8 @@ message GetRelationsRequest {
             ignore_empty: true,
             cel: {
                 id: "get_relations.subject_relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -622,8 +622,8 @@ message CheckRequest {
             required: true
             cel: {
                 id: "check.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -670,8 +670,8 @@ message CheckRequest {
             required: true
             cel: {
                 id: "check.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -730,8 +730,8 @@ message CheckPermissionRequest {
             required: true
             cel: {
                 id: "check_permission.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -778,8 +778,8 @@ message CheckPermissionRequest {
             required: true
             cel: {
                 id: "check_permission.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -825,8 +825,8 @@ message CheckRelationRequest {
             required: true
             cel: {
                 id: "check_relation.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -857,8 +857,8 @@ message CheckRelationRequest {
             required: true
             cel: {
                 id: "check_relation.relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -873,8 +873,8 @@ message CheckRelationRequest {
             required: true
             cel: {
                 id: "check_relation.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -923,8 +923,8 @@ message GetGraphRequest {
             ignore_empty: true,
             cel: {
                 id: "get_graph.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -955,8 +955,8 @@ message GetGraphRequest {
             ignore_empty: true,
             cel: {
                 id: "get_graph.relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -971,8 +971,8 @@ message GetGraphRequest {
             ignore_empty: true,
             cel: {
                 id: "get_graph.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -1003,8 +1003,8 @@ message GetGraphRequest {
             ignore_empty: true,
             cel: {
                 id: "get_graph.subject_relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64

--- a/proto/aserto/directory/writer/v3/writer.proto
+++ b/proto/aserto/directory/writer/v3/writer.proto
@@ -135,8 +135,8 @@ message DeleteObjectRequest {
             required: true
             cel: {
                 id: "delete_object.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -193,8 +193,8 @@ message DeleteRelationRequest {
         (buf.validate.field) = {
             cel: {
                 id: "delete_relation.object_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -225,8 +225,8 @@ message DeleteRelationRequest {
             required: true
             cel: {
                 id: "delete_relation.relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -241,8 +241,8 @@ message DeleteRelationRequest {
             required: true
             cel: {
                 id: "delete_relation.subject_type"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64
@@ -273,8 +273,8 @@ message DeleteRelationRequest {
             ignore_empty: true,
             cel: {
                 id: "delete_relation.subject_relation"
-                message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: "this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')"
+                message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
+                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
             }
             string: {
                 max_len: 64

--- a/proto/aserto/directory/writer/v3/writer.proto
+++ b/proto/aserto/directory/writer/v3/writer.proto
@@ -136,7 +136,7 @@ message DeleteObjectRequest {
             cel: {
                 id: "delete_object.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -194,7 +194,7 @@ message DeleteRelationRequest {
             cel: {
                 id: "delete_relation.object_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -226,7 +226,7 @@ message DeleteRelationRequest {
             cel: {
                 id: "delete_relation.relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -242,7 +242,7 @@ message DeleteRelationRequest {
             cel: {
                 id: "delete_relation.subject_type"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64
@@ -274,7 +274,7 @@ message DeleteRelationRequest {
             cel: {
                 id: "delete_relation.subject_relation"
                 message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
-                expression: ""this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')""
+                expression: "this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')"
             }
             string: {
                 max_len: 64


### PR DESCRIPTION
Switch type identifier 
* from: 
  * this.matches('^[a-z][a-z0-9\\\\._-]{1,62}[a-z0-9]$')
  * message: "must be all lowercase, start with a letter, can contain letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
* to: 
  * this.matches('^[a-zA-Z][a-zA-Z0-9\\\\._-]{1,62}[a-zA-Z0-9]$')
  * message: "must start with a letter, can contain mixed case letters, digits, dots, underscores, and dashes, and must end with a letter or digit"
